### PR TITLE
Added PyQt5 as a setup.py dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,7 @@ setup(name='quick',
       py_modules=['quick'],
       install_requires=[
           'click>=5.0',
+          'PyQt5'
           ],
       extras_require={
           'qtstyle':  ["qdarkstyle"]


### PR DESCRIPTION
PyQt5 was not included in setup.py which means that pip/poetry didn't install the dependency correctly.